### PR TITLE
Feature/connect search

### DIFF
--- a/leafsmart-front-end/.env.example
+++ b/leafsmart-front-end/.env.example
@@ -6,6 +6,7 @@ REACT_APP_GEONAMES_USERNAME=yourusername
 REACT_APP_GEONAMES_URL=http://api.geonames.org/searchJSON
 
 REACT_APP_TELEPORT_CITYINFO_ENDPOINT="https://api.teleport.org/api/cities/"
+REACT_APP_TELEPORT_QOL_ENDPOINT="https://api.teleport.org/api/urban_areas/"
 
 # Sign up and documentation available here: https://developer.ticketmaster.com/
 REACT_APP_TICKETMASTER_EVENTS_ENDPOINT="https://app.ticketmaster.com/discovery/v2/events.json"

--- a/leafsmart-front-end/.env.example
+++ b/leafsmart-front-end/.env.example
@@ -1,0 +1,6 @@
+PORT=3002
+# How to get a Geonames Username?
+# Register here and confirm email:http://www.geonames.org/login
+# Enable Free web services here: https://www.geonames.org/manageaccount
+REACT_APP_GEONAMES_USERNAME=yourusername
+REACT_APP_GEONAMES_URL=http://api.geonames.org/searchJSON

--- a/leafsmart-front-end/.env.example
+++ b/leafsmart-front-end/.env.example
@@ -4,3 +4,5 @@ PORT=3002
 # Enable Free web services here: https://www.geonames.org/manageaccount
 REACT_APP_GEONAMES_USERNAME=yourusername
 REACT_APP_GEONAMES_URL=http://api.geonames.org/searchJSON
+
+REACT_APP_TELEPORT_CITYINFO_ENDPOINT="https://api.teleport.org/api/cities/"

--- a/leafsmart-front-end/.env.example
+++ b/leafsmart-front-end/.env.example
@@ -6,3 +6,7 @@ REACT_APP_GEONAMES_USERNAME=yourusername
 REACT_APP_GEONAMES_URL=http://api.geonames.org/searchJSON
 
 REACT_APP_TELEPORT_CITYINFO_ENDPOINT="https://api.teleport.org/api/cities/"
+
+# Sign up and documentation available here: https://developer.ticketmaster.com/
+REACT_APP_TICKETMASTER_EVENTS_ENDPOINT="https://app.ticketmaster.com/discovery/v2/events.json"
+REACT_APP_TICKETMASTER_EVENTS_KEY=yourkey

--- a/leafsmart-front-end/package-lock.json
+++ b/leafsmart-front-end/package-lock.json
@@ -14,6 +14,7 @@
         "postcss-cli": "^10.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-number-format": "^4.9.3",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
         "react-select-async-paginate": "^0.6.2",
@@ -15467,6 +15468,18 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-number-format": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-4.9.3.tgz",
+      "integrity": "sha512-am1A1xYAbENuKJ+zpM7V+B1oRTSeOHYltqVKExznIVFweBzhLmOBmyb1DfIKjHo90E0bo1p3nzVJ2NgS5xh+sQ==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -29984,6 +29997,14 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "react-number-format": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-4.9.3.tgz",
+      "integrity": "sha512-am1A1xYAbENuKJ+zpM7V+B1oRTSeOHYltqVKExznIVFweBzhLmOBmyb1DfIKjHo90E0bo1p3nzVJ2NgS5xh+sQ==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
     },
     "react-refresh": {
       "version": "0.11.0",

--- a/leafsmart-front-end/package-lock.json
+++ b/leafsmart-front-end/package-lock.json
@@ -7047,14 +7047,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/dotenv-expand": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
@@ -15579,6 +15571,14 @@
         }
       }
     },
+    "node_modules/react-scripts/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/react-select": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.4.0.tgz",
@@ -24024,11 +24024,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
-    },
     "dotenv-expand": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
@@ -30065,6 +30060,13 @@
         "webpack-dev-server": "^4.6.0",
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+        }
       }
     },
     "react-select": {

--- a/leafsmart-front-end/package.json
+++ b/leafsmart-front-end/package.json
@@ -9,6 +9,7 @@
     "postcss-cli": "^10.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-number-format": "^4.9.3",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "react-select-async-paginate": "^0.6.2",

--- a/leafsmart-front-end/src/App.js
+++ b/leafsmart-front-end/src/App.js
@@ -1,18 +1,20 @@
-import React, { Fragment, useState, useEffect } from "react";
 import Nav from "./components/Nav";
 import Events from "./components/Events"
-import "./App.scss";
 import CityFacts from "./components/CityFacts";
 import QoLData from "./components/QoLData";
 import Search from "./components/Search";
-import './styles/main.css';
 
-const handleOnSearchChange = (searchData) => {
-  //response contains { label: "Toronto, ON", value: "43.670277777 -79.386666666" }
-    console.log(searchData);
-}
+import './styles/main.css';
+import "./App.scss";
+
 
 const App = () => {
+
+  const handleOnSearchChange = (searchData) => {
+    //response contains data such as {value: '5946768 53.55014 -113.46871', label: 'Edmonton, Alberta'}
+      console.log(searchData);
+  }
+
   return (
     <main className="layout">
       <section className="nav-bar">

--- a/leafsmart-front-end/src/App.js
+++ b/leafsmart-front-end/src/App.js
@@ -1,18 +1,28 @@
+import { useState } from "react";
+
 import Nav from "./components/Nav";
 import Events from "./components/Events"
 import CityFacts from "./components/CityFacts";
 import QoLData from "./components/QoLData";
 import Search from "./components/Search";
 
-import './styles/main.css';
+import "./styles/main.css";
 import "./App.scss";
 
 
 const App = () => {
+  const [cityName, setCityName] = useState(null);
+  const [coordinates, setCoordinates] = useState({});
+  const [geonameId, setGeonameId] = useState(null);
 
   const handleOnSearchChange = (searchData) => {
-    //response contains data such as {value: '5946768 53.55014 -113.46871', label: 'Edmonton, Alberta'}
-      console.log(searchData);
+    //sample searchData: {value: '5946768 53.55014 -113.46871', label: 'Edmonton, Alberta'}
+    const lowercasedCity = searchData.label.split(",")[0].toLowerCase();
+    const [geo, lat, lon] = searchData.value.split(" ");
+
+    setCityName(lowercasedCity);
+    setCoordinates({lat: lat, lon: lon});
+    setGeonameId(geo);
   }
 
   return (
@@ -25,7 +35,9 @@ const App = () => {
         <div>
           <h1 className="text-3xl font-bold underline text-purple-600 hover:bg-amber-50">Widgets</h1>
           <Search onSearchChange={handleOnSearchChange}/>
-          <CityFacts />
+          <CityFacts
+            geonameId={geonameId}
+          />
           <Events />
           <QoLData />
         </div>

--- a/leafsmart-front-end/src/App.js
+++ b/leafsmart-front-end/src/App.js
@@ -41,7 +41,9 @@ const App = () => {
           <Events
             cityName={cityName}
           />
-          <QoLData />
+          <QoLData
+            cityName={cityName}
+          />
         </div>
       </section>
     </main>

--- a/leafsmart-front-end/src/App.js
+++ b/leafsmart-front-end/src/App.js
@@ -38,7 +38,9 @@ const App = () => {
           <CityFacts
             geonameId={geonameId}
           />
-          <Events />
+          <Events
+            cityName={cityName}
+          />
           <QoLData />
         </div>
       </section>

--- a/leafsmart-front-end/src/components/CityFacts.js
+++ b/leafsmart-front-end/src/components/CityFacts.js
@@ -1,28 +1,33 @@
 import { React, useState, useEffect } from "react";
 import axios from "axios"
 
-const CityFacts = () => {
+const apiUrl = process.env.REACT_APP_TELEPORT_CITYINFO_ENDPOINT;
+
+const CityFacts = (props) => {
+  const { geonameId } = props;
   const [city, setCity] = useState([]);
+
   useEffect(() => {
-    let geonameid = 6324729;
-    // Teleport API
-    const api = 
-    `https://api.teleport.org/api/cities/geonameid:${geonameid}`
-    
-    axios.get(`${api}`)
-    .then((res)=>{
-      const data = res.data
-      setCity(data);
-    })
-    .catch((err)=>{
-      console.log(err)
-    })
-}, []);
+    if ( geonameId) {
+      axios.get(`${apiUrl}geonameid:${geonameId}`)
+      .then((res)=>{
+        setCity(res.data);
+      })
+      .catch((err)=>{
+        console.log(err)
+      })
+    }
+  }, [geonameId]);
+
   return (
     <main>
       <section>
-        <h1>{city.name}</h1>
-        <h1>Population: {city.population}</h1>
+        { geonameId && (
+          <>
+            <h1>{city.name}</h1>
+            <p>Population: {city.population}</p>
+          </>
+        )}
       </section>
     </main>
   );

--- a/leafsmart-front-end/src/components/CityFacts.js
+++ b/leafsmart-front-end/src/components/CityFacts.js
@@ -27,7 +27,11 @@ const CityFacts = (props) => {
           <>
             <h1>{city.name}</h1>
             <h2 className="inline">Population: </h2>
-            <NumberFormat value={city.population} thousandSeparator/>
+            <NumberFormat
+              value={city.population}
+              thousandSeparator
+              displayType="text"
+            />
           </>
         )}
       </section>

--- a/leafsmart-front-end/src/components/CityFacts.js
+++ b/leafsmart-front-end/src/components/CityFacts.js
@@ -1,4 +1,5 @@
 import { React, useState, useEffect } from "react";
+import NumberFormat from "react-number-format";
 import axios from "axios"
 
 const apiUrl = process.env.REACT_APP_TELEPORT_CITYINFO_ENDPOINT;
@@ -25,7 +26,8 @@ const CityFacts = (props) => {
         { geonameId && (
           <>
             <h1>{city.name}</h1>
-            <p>Population: {city.population}</p>
+            <h2 className="inline">Population: </h2>
+            <NumberFormat value={city.population} thousandSeparator/>
           </>
         )}
       </section>

--- a/leafsmart-front-end/src/components/EventCard.js
+++ b/leafsmart-front-end/src/components/EventCard.js
@@ -1,14 +1,16 @@
 import React from 'react'
 
 export default function EventCard(props) {
+  const { name, image, date, url} = props;
+
   return (
     <li>
-            <h1>{props.name}</h1>
-      <img 
-      src={props.image}
-      alt={props.name}/>
-      <p>Date: {props.date}</p>
-      <a href={props.url}>Find your tickets here!</a>
+            <h1>{name}</h1>
+      <img
+      src={image}
+      alt={name}/>
+      <p>Date: {date}</p>
+      <a href={url}>Find your tickets here!</a>
     </li>
   );
 }

--- a/leafsmart-front-end/src/components/Events.js
+++ b/leafsmart-front-end/src/components/Events.js
@@ -13,22 +13,26 @@ const date = (year+"-"+month+"-"+day+"T19:00:00Z");
 const apiUrl = process.env.REACT_APP_TICKETMASTER_EVENTS_ENDPOINT;
 const apiKey = process.env.REACT_APP_TICKETMASTER_EVENTS_KEY;
 
-const Events = () => {
+const Events = (props) => {
+  const { cityName } = props;
   const [events, setEvents] = useState([]);
 
   //api call to pull in the events data from ticketmaster
   useEffect(() => {
-     axios.get(`${apiUrl}?apikey=${apiKey}&city=toronto&sort=date,name,asc&startDateTime=${date}`)
-      .then((res) => {
-        const data = res.data['_embedded']['events'];
-        setEvents(data);
-      })
-      .catch((err) => {
-        console.log(err);
-      });
-  }, []);
+    if (cityName) {
+      axios.get(`${apiUrl}?apikey=${apiKey}&city=${cityName}&sort=date,name,asc&startDateTime=${date}`)
+       .then((res) => {
+         const data = res.data['_embedded']['events'];
+         setEvents(data);
+       })
+       .catch((err) => {
+         console.log(err);
+       });
+    }
+  }, [cityName]);
 
   //mapping the data from the events array to showcase via the events list item breakdown.
+  //BUG -- WHAT HAPPENS WHEN AN EMPTY ARRAY IS RETURNED?
   const eventsArr = events.map((events) => {
     return (
       <EventCard

--- a/leafsmart-front-end/src/components/Events.js
+++ b/leafsmart-front-end/src/components/Events.js
@@ -1,28 +1,31 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
+
 import EventCard from './EventCard';
 
+// get current date
 const today = new Date();
 const year = today.getFullYear()
 const day = ("0" + today.getDate()).slice(-2);
 const month = ("0" + (today.getMonth()+1)).slice(-2)
 const date = (year+"-"+month+"-"+day+"T19:00:00Z");
 
-const api = `https://app.ticketmaster.com/discovery/v2/events.json?apikey=6gMe63zUGZXgI1NElCvwwZZfzG8Soesu`;
+const apiUrl = process.env.REACT_APP_TICKETMASTER_EVENTS_ENDPOINT;
+const apiKey = process.env.REACT_APP_TICKETMASTER_EVENTS_KEY;
 
 const Events = () => {
   const [events, setEvents] = useState([]);
 
   //api call to pull in the events data from ticketmaster
   useEffect(() => {
-     axios.get(`${api}&city=toronto&sort=date,name,asc&startDateTime=${date}`)
-    .then((res) => {
-      const data = res.data['_embedded']['events'];
-      setEvents(data);
-    })
-    .catch((err) => {
-      console.log(err);
-    });
+     axios.get(`${apiUrl}?apikey=${apiKey}&city=toronto&sort=date,name,asc&startDateTime=${date}`)
+      .then((res) => {
+        const data = res.data['_embedded']['events'];
+        setEvents(data);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
   }, []);
 
   //mapping the data from the events array to showcase via the events list item breakdown.

--- a/leafsmart-front-end/src/components/QoLData.js
+++ b/leafsmart-front-end/src/components/QoLData.js
@@ -1,103 +1,23 @@
 import { React, useState, useEffect } from "react";
 import axios from "axios";
-import QoLDataCard from "./QoLDataCard";
 import { filterQoL } from "../helpers/selectors";
+import { kebabCase } from "../helpers/formats";
 
-// const cityScore = {
-//   _links: {
-//     curies: [
-//       {
-//         href: "https://developers.teleport.org/api/resources/Location/#!/relations/{rel}/",
-//         name: "location",
-//         templated: true,
-//       },
-//       {
-//         href: "https://developers.teleport.org/api/resources/City/#!/relations/{rel}/",
-//         name: "city",
-//         templated: true,
-//       },
-//       {
-//         href: "https://developers.teleport.org/api/resources/UrbanArea/#!/relations/{rel}/",
-//         name: "ua",
-//         templated: true,
-//       },
-//       {
-//         href: "https://developers.teleport.org/api/resources/Country/#!/relations/{rel}/",
-//         name: "country",
-//         templated: true,
-//       },
-//       {
-//         href: "https://developers.teleport.org/api/resources/Admin1Division/#!/relations/{rel}/",
-//         name: "a1",
-//         templated: true,
-//       },
-//       {
-//         href: "https://developers.teleport.org/api/resources/Timezone/#!/relations/{rel}/",
-//         name: "tz",
-//         templated: true,
-//       },
-//     ],
-//     self: {
-//       href: "https://api.teleport.org/api/urban_areas/slug:halifax/scores/",
-//     },
-//   },
-//   categories: [
-//     { color: "#f3c32c", name: "Housing", score_out_of_10: 6.895000000000001 },
-//     {
-//       color: "#f3d630",
-//       name: "Cost of Living",
-//       score_out_of_10: 4.9430000000000005,
-//     },
-//     { color: "#f4eb33", name: "Startups", score_out_of_10: 3.624 },
-//     {
-//       color: "#d2ed31",
-//       name: "Venture Capital",
-//       score_out_of_10: 2.2840000000000003,
-//     },
-//     {
-//       color: "#7adc29",
-//       name: "Travel Connectivity",
-//       score_out_of_10: 1.5699999999999998,
-//     },
-//     { color: "#36cc24", name: "Commute", score_out_of_10: 5.402750000000001 },
-//     { color: "#19ad51", name: "Business Freedom", score_out_of_10: 8.966 },
-//     { color: "#0d6999", name: "Safety", score_out_of_10: 7.188500000000001 },
-//     { color: "#051fa5", name: "Healthcare", score_out_of_10: 8.67 },
-//     { color: "#150e78", name: "Education", score_out_of_10: 5.42 },
-//     {
-//       color: "#3d14a4",
-//       name: "Environmental Quality",
-//       score_out_of_10: 7.618499999999999,
-//     },
-//     { color: "#5c14a1", name: "Economy", score_out_of_10: 5.8405000000000005 },
-//     { color: "#88149f", name: "Taxation", score_out_of_10: 7.2745000000000015 },
-//     {
-//       color: "#b9117d",
-//       name: "Internet Access",
-//       score_out_of_10: 6.123500000000001,
-//     },
-//     {
-//       color: "#d10d54",
-//       name: "Leisure \u0026 Culture",
-//       score_out_of_10: 3.942,
-//     },
-//     { color: "#e70c26", name: "Tolerance", score_out_of_10: 7.853499999999999 },
-//     { color: "#f1351b", name: "Outdoors", score_out_of_10: 4.023 },
-//   ],
-//   summary:
-//     "\u003cp\u003eHalifax, Canada, is among the top cities with a \u003cb\u003efree business environment\u003c/b\u003e.\n\n    \n        According to our city rankings, this is a good place to live with high ratings in \u003cb\u003ehousing\u003c/b\u003e, \u003cb\u003esafety\u003c/b\u003e and \u003cb\u003ehealthcare\u003c/b\u003e.\n    \n\n    \n\u003c/p\u003e\n\n",
-//   teleport_city_score: 60.742027027027035,
-// };
+import QoLDataCard from "./QoLDataCard";
 
-const QoLData = () => {
+const QoLData = (props) => {
+  const { cityName } = props;
   const [slugScore, setSlugScore] = useState([]);
-  useEffect(() => {
-      let cityName = "halifax";
-      // Teleport API
-      const api = 
-        `https://api.teleport.org/api/urban_areas/slug:${cityName}/scores/`
-      
 
+  const apiUrl = process.env.REACT_APP_TELEPORT_QOL_ENDPOINT;
+
+  useEffect(() => {
+    if (cityName) {
+      const api =
+        `${apiUrl}slug:${kebabCase(cityName)}/scores/`
+      console.log(api);
+
+      //TODO: Handle showing a message when endpoint is not defined, returns no data
       axios.get(`${api}`)
       .then((res)=>{
         const data = res.data["categories"]
@@ -106,9 +26,10 @@ const QoLData = () => {
       .catch((err)=>{
         console.log(err)
       })
-  }, []);
+    }
 
-  //console.log(slugScore)
+  }, [cityName]);
+
   //get slugScores for a city
   const categoriesArr = filterQoL(slugScore).map((slugScore) => {
     return (

--- a/leafsmart-front-end/src/components/Search.js
+++ b/leafsmart-front-end/src/components/Search.js
@@ -2,16 +2,8 @@ import { useState } from 'react';
 import { AsyncPaginate } from "react-select-async-paginate";
 import axios from 'axios';
 
-//https://rapidapi.com/wirefreethought/api/geodb-cities
-const apiUrl = "https://wft-geo-db.p.rapidapi.com/v1/geo/cities"
-const apiOptions = {
-	method: 'GET',
-	headers: {
-		'X-RapidAPI-Key': '80d7167f11msh6c7145e3fd1d1a4p16cb90jsn629fc6ec6c82',
-		'X-RapidAPI-Host': 'wft-geo-db.p.rapidapi.com'
-	}
-};
-
+const apiUser = process.env.REACT_APP_GEONAMES_USERNAME;
+const apiUrl = process.env.REACT_APP_GEONAMES_URL;
 
 const Search = (props) => {
   const { onSearchChange } = props;
@@ -23,13 +15,13 @@ const Search = (props) => {
   }
 
   const loadOptions = (inputValue) => {
-    return axios.get(`${apiUrl}?countryIds=CA&minPopulation=100000&namePrefix=${inputValue}&types=CITY`, apiOptions)
+    return axios.get(`${apiUrl}?name_startsWith=${inputValue}&cities=cities5000&country=CA&featureClass=P&maxRows=5&username=${apiUser}`)
       .then(res => {
         return {
-          options: res.data.data.map((city => {
+          options: res.data.geonames.map((city => {
             return {
-              value: `${city.latitude} ${city.longitude}`,
-              label: `${city.city}, ${city.regionCode}`
+              value: `${city.geonameId} ${city.lat} ${city.lng}`,
+              label: `${city.toponymName}, ${city.adminName1}`
             }
           }))
         }

--- a/leafsmart-front-end/src/helpers/formats.js
+++ b/leafsmart-front-end/src/helpers/formats.js
@@ -1,0 +1,7 @@
+const kebabCase = (string) => {
+  return string.split(" ").join("-");
+};
+
+module.exports = {
+  kebabCase
+};

--- a/leafsmart-front-end/src/styles/main.css
+++ b/leafsmart-front-end/src/styles/main.css
@@ -387,6 +387,9 @@ video {
   --tw-backdrop-saturate:  ;
   --tw-backdrop-sepia:  ;
 }
+.inline {
+  display: inline;
+}
 .text-3xl {
   font-size: 1.875rem;
   line-height: 2.25rem;
@@ -417,16 +420,6 @@ body {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
-}
-
-.hover\:bg-blue-50:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(239 246 255 / var(--tw-bg-opacity));
-}
-
-.hover\:bg-purple-50:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(250 245 255 / var(--tw-bg-opacity));
 }
 
 .hover\:bg-amber-50:hover {


### PR DESCRIPTION
Hello pals! 

### Before:

- [ ] `npm i`
- [ ] copy .env.example and fill in with appropriate API keys. Make a copy annd rename it to .env. 

### Expect:
- Widgets should now load only when you search for results! 

*issue: if searches are run back-to-back and any of them don't return events or QoL data, the data from the previous search will linger. Looking for help brainstorming solutions to this conditional rendering problem! 