### PR TITLE
Bugfix/qol regions

### DIFF
--- a/leafsmart-back-end/package-lock.json
+++ b/leafsmart-back-end/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "leafsmart-back-end",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -292,7 +293,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",

--- a/leafsmart-front-end/src/components/Contact.js
+++ b/leafsmart-front-end/src/components/Contact.js
@@ -17,7 +17,7 @@ const Contact = () => {
       photo: "/team-photos/andrea.jpg",
       email: "almadsen792@live.ca",
       githubLink: "https://github.com/b1u3too",
-      githubUsername: "b1uetoo",
+      githubUsername: "b1u3too",
     },
     {
       name: "Matt Stankovich",

--- a/leafsmart-front-end/src/components/Events.js
+++ b/leafsmart-front-end/src/components/Events.js
@@ -31,10 +31,9 @@ const Events = (props) => {
           setEvents(data);
           setNoEvents(false);
         })
-        .catch((err) => {
+        .catch(() => {
           setEvents([]);
           setNoEvents(true);
-          console.log(err);
         });
     }
   }, [cityName]);

--- a/leafsmart-front-end/src/components/Weather.js
+++ b/leafsmart-front-end/src/components/Weather.js
@@ -28,7 +28,6 @@ const Weather = (props) => {
 
       Promise.all([forecastPromise, currentWeatherPromise])
         .then((res) => {
-          console.log(res);
           const forecastResponse = res[0];
           const forecastData = forecastResponse.data["data"];
           const currentWeatherResponse = res[1];

--- a/leafsmart-front-end/src/components/cityData/CityFacts.js
+++ b/leafsmart-front-end/src/components/cityData/CityFacts.js
@@ -3,7 +3,6 @@ import NumberFormat from "react-number-format";
 const CityFacts = (props) => {
   const { cityName, cityPop, imageData } = props;
 
-  console.log("imageData Keys: ", Object.keys(imageData).length);
   return (
     <section>
       { cityName && (


### PR DESCRIPTION
Fixes #96

A person searching for London, Ontario won't get QoL or Image data about London, England in error.

Matching between selected country and slug: scheme ID for Teleport Urban Areas endpoints is now checked with a single additional call before those slug: endpoints are called. 

Let me know what y'all think! 